### PR TITLE
fix: 소셜 로그인 시 RedirectUrl로 이동하지 않는 이슈 해결 #43 close

### DIFF
--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -9,9 +9,10 @@ export const signInWithProvider = async (provider) => {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
+      redirectTo: 'http://localhost:5173/oauth',
       queryParams: {
-        access_type: 'offline',
-        prompt: 'consent',
+        access_type: 'offline', // 리프레시 토큰 발급
+        prompt: 'consent', // 소셜 로그인 시 항상 권한 요청 화면 표시
       },
     },
   });

--- a/src/pages/Oauth/OauthPage.jsx
+++ b/src/pages/Oauth/OauthPage.jsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+function OauthPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const exchangeTokenForUser = async () => {
+      // URL에서 파라미터 추출
+      const params = new URLSearchParams(location.hash.slice(1));
+      // 액세스 토큰 파라미터 추출
+      const accessToken = params.get('access_token');
+
+      try {
+        if (accessToken) {
+          navigate('/home');
+          window.alert('로그인에 성공했어요.', 'success');
+        } else {
+          navigate('/login');
+          window.alert('로그인에 실패했어요. 다시 시도해주세요.', 'error');
+        }
+      } catch (error) {
+        window.alert(`${error}`, 'error');
+      }
+    };
+
+    exchangeTokenForUser();
+  }, [location.hash, navigate]);
+
+  return (
+    <div height="100vh">
+      <div>로그인 중, 잠시만 기다려주세요...</div>
+    </div>
+  );
+}
+
+export default OauthPage;

--- a/src/routes/RouteDef.jsx
+++ b/src/routes/RouteDef.jsx
@@ -7,8 +7,7 @@ import OrderPage from '../pages/MyPage/OrderPage/OrderPage';
 import OrderDetailPage from '../pages/MyPage/OrderDetailPage/OrderDetailPage';
 import PaymentsPage from '../pages/PaymentsPage/PaymentsPage';
 import PetProfileSurveyPage from '../pages/PetProfileSurveyPage/PetProfileSurveyPage';
-import ApiPage from '../pages/api/ApiPage';
-import { element } from 'prop-types';
+import OauthPage from '../pages/Oauth/OauthPage';
 
 // 페이지 URL 및 렌더링할 페이지 컴포넌트 정보를 저장하는 객체
 export const Screens = {
@@ -44,9 +43,9 @@ export const Screens = {
     path: '/survey',
     element: <PetProfileSurveyPage />,
   },
-  ApiPage: { // 새 페이지 추가
-    path: '/ApiPage',
-    element: <ApiPage />,
+  Oauth: {
+    path: '/oauth',
+    element: <OauthPage />,
   },
   // 페이지를 추가 시 아래에 새로운 페이지 객체 작성
   // Survey: {


### PR DESCRIPTION
## 연관된 이슈

> #43 

## 작업 내용

> - useLogin 훅의 signInWithOAuth에 redirectTo 주소 `/oauth`를 추가했습니다.
> - `/oauth`에 해당하는 `OauthPage` 컴포넌트를 구현했습니다.
>     - `/oauth` 페이지 진입 시 url에서 access-token을 추출합니다.
>     - access-token 값에 따라 로그인 성공 시 `/home`으로, 실패 시 `/login`으로 이동합니다.

### 스크린샷 (선택)

## 리뷰 요구사항(선택)

> 
