### PR TITLE
feat: OAuth 페이지 최초 로그인 분기 추가 및 alert를 모달로 변경 #76 close

### DIFF
--- a/src/components/PetProfileSurvey/ProfileSurvey.jsx
+++ b/src/components/PetProfileSurvey/ProfileSurvey.jsx
@@ -60,7 +60,6 @@ function ProfileSurvey({ step, petProfileData, setPetProfileData, validateStep, 
           ) : (
             <div className={`${styles.inputWrapper}`}>
               {/* 3-2. 대략적인 개월수만 알고 있는 경우 */}
-              {/* TODO  */}
               <InputNumber
                 type="number"
                 value={petProfileData.birth_year}

--- a/src/hooks/usePetProfileSurvey.js
+++ b/src/hooks/usePetProfileSurvey.js
@@ -1,25 +1,9 @@
 import { useState } from 'react';
-import updatePetProfile from '../services/updatePetProfile';
-import insertPetProfile from '../services/insertPetProfile';
 
-/* 반려견 프로필 생성 및 DB 저장 */
+/* 반려견 프로필 생성 */
 function usePetProfileSurvey() {
   const [petProfileData, setPetProfileData] = useState();
   const [step, setStep] = useState(1);
-
-  /* 신규 반려견 프로필 등록 */
-  // 1-2. DB에 새로운 반려견 프로필을 저장
-  async function postProfileData() {
-    try {
-      insertPetProfile(petProfileData);
-      window.alert('프로필 생성이 완료되었어요.'); // TODO 모달로 변경, 예외처리 로직 훅에 넣기
-    } catch (error) {
-      console.log(error);
-      window.alert('반려견 프로필 생성에 실패했어요. 다시 시도해주세요.'); // TODO 모달로 변경, 예외처리 로직 훅에 넣기
-      return;
-    }
-    window.location.href = '/home';
-  }
 
   /* 반려견 프로필 등록 설문 유효성 검사 */
   function validateStep() {
@@ -51,7 +35,6 @@ function usePetProfileSurvey() {
     step, // 설문 진행도
     setStep, // 설문 진행도 변경 함수
     petProfileData, // 설문 데이터
-    postProfileData, // 설문 데이터 생성 함수
     setPetProfileData, // 설문 데이터 상태 변경 함수
     validateStep, // 설문 단계별 유효성 검사
   };

--- a/src/pages/Oauth/OauthPage.jsx
+++ b/src/pages/Oauth/OauthPage.jsx
@@ -3,6 +3,17 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/useAuthStore'; // useAuthStore import
 import supabase from '../../services/supabaseClient'; // Supabase 클라이언트 import
 import DefaultModal from '../../components/Common/Modal/DefaultModal';
+import styled from 'styled-components';
+import { CircularProgress } from '@mui/material';
+import styles from '../../pages/Oauth/OauthPage.module.css';
+
+const OAuthContainer = styled`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 function OauthPage() {
   const location = useLocation();
@@ -73,7 +84,6 @@ function OauthPage() {
 
           if (error) {
             console.error('Error fetching user:', error.message);
-            // window.alert('Failed to retrieve user information!', 'error');
 
             setIsFailedModalOpen(true);
             // navigate('/login');
@@ -114,8 +124,8 @@ function OauthPage() {
   }, []);
 
   return (
-    <div style="display: flex; justify-content: center; align-items: center; height: 100vh">
-      <div>로그인 중, 잠시만 기다려주세요...</div>
+    <div className={styles.container}>
+      <CircularProgress />
       <DefaultModal
         title={'로그인 성공'}
         content={'로그인에 성공했어요.'}

--- a/src/pages/Oauth/OauthPage.jsx
+++ b/src/pages/Oauth/OauthPage.jsx
@@ -1,35 +1,88 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../stores/useAuthStore'; // useAuthStore import
 import supabase from '../../services/supabaseClient'; // Supabase 클라이언트 import
+import DefaultModal from '../../components/Common/Modal/DefaultModal';
 
 function OauthPage() {
   const location = useLocation();
-  const navigate = useNavigate();
   const { setUser } = useAuthStore(); // useAuthStore에서 setUser 가져오기
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
+  const [isFailedModalOpen, setIsFailedModalOpen] = useState(false);
+  const [nextPage, setNextPage] = useState('/mypage');
+
+  const params = new URLSearchParams(location.hash.slice(1));
+  const accessToken = params.get('access_token');
+
+  // 최초 로그인 여부를 받아와 분기 처리
+  const getisFirstLogin = async (user_id) => {
+    try {
+      // user.id로 DB에서 사용자 정보 조회
+      const { data, error } = await supabase.from('user').select().eq('user_id', `${user_id}`);
+      const user = data[0];
+
+      if (error) {
+        console.error(error);
+        isFailedModalOpen(true);
+        throw error;
+      }
+
+      if (user.is_first_login) {
+        // 최초 로그인인 경우 최초 로그인 여부를 DB에 업데이트하고 설문 페이지로 이동
+        setNextPage('/survey');
+        await updateFirstLogin(user_id);
+        setIsSuccessModalOpen(true);
+        return;
+      } else {
+        // 최초 로그인이 아닌 경우 홈 페이지로 이동
+        setNextPage('/home');
+        setIsSuccessModalOpen(true);
+        return;
+      }
+    } catch (error) {
+      console.error(error);
+      isFailedModalOpen(true);
+      throw error;
+    }
+  };
+
+  // 최초 로그인 여부를 DB에 업데이트
+  const updateFirstLogin = async (user_id) => {
+    try {
+      // 로그인한 유저의 최초 로그인 여부를 false로 변경
+      const { data, error } = await supabase.from('user').update({ is_first_login: false }).eq('user_id', `${user_id}`);
+
+      if (error) {
+        console.error(error);
+        isFailedModalOpen(true);
+        throw error;
+      }
+    } catch (error) {
+      console.error(error);
+      isFailedModalOpen(true);
+      throw error;
+    }
+  };
 
   React.useEffect(() => {
     const exchangeTokenForUser = async () => {
-      const params = new URLSearchParams(location.hash.slice(1));
-      const accessToken = params.get('access_token');
-
       try {
         if (accessToken) {
-          console.log("Access Token:", accessToken);
-
           // Supabase API를 사용하여 사용자 정보 가져오기
           const { data, error } = await supabase.auth.getUser(accessToken);
 
           if (error) {
             console.error('Error fetching user:', error.message);
             // window.alert('Failed to retrieve user information!', 'error');
-            navigate('/login');
+
+            setIsFailedModalOpen(true);
+            // navigate('/login');
             return;
           }
 
           const userData = data.user;
 
-          // 사용자 정보 저장
+          // 로그인에 성공한 경우 user data를 AuthStore에 저장
           if (userData) {
             setUser({
               id: userData.id,
@@ -39,29 +92,48 @@ function OauthPage() {
               avatarUrl: userData.user_metadata.avatar_url,
             });
 
-            navigate('/mypage'); // 페이지 이동
-            alert('로그인 완료');
+            // 최초 로그인 여부에 따라 분기
+            getisFirstLogin(userData.id);
+            return;
           } else {
-            navigate('/login');
-            // window.alert('User data is not available!', 'error');
+            console.error('no User Data');
+            setIsFailedModalOpen(true);
           }
         } else {
-          navigate('/login');
-          // window.alert('No access token found!', 'error');
+          console.error('no access token');
+          setIsFailedModalOpen(true);
           console.error(error.message);
-          
         }
       } catch (error) {
-        // window.alert(`Error: ${error.message}`, 'error');
+        console.error(error);
+        setIsFailedModalOpen(true);
       }
     };
 
     exchangeTokenForUser();
-  }, [location.hash, navigate, setUser]); // setUser를 의존성 배열에 추가
+  }, []);
 
   return (
-    <div height="100vh">
+    <div style="display: flex; justify-content: center; align-items: center; height: 100vh">
       <div>로그인 중, 잠시만 기다려주세요...</div>
+      <DefaultModal
+        title={'로그인 성공'}
+        content={'로그인에 성공했어요.'}
+        isOpen={isSuccessModalOpen}
+        setIsOpen={() => setIsSuccessModalOpen(false)}
+        onYesClick={() => {
+          window.location.href = `${nextPage}`;
+        }}
+      />
+      <DefaultModal
+        title={'로그인 실패'}
+        content={'로그인에 실패했어요.\n다시 시도해주세요.'}
+        isOpen={isFailedModalOpen}
+        setIsOpen={() => setIsFailedModalOpen(false)}
+        onYesClick={() => {
+          window.location.href = '/login';
+        }}
+      />
     </div>
   );
 }

--- a/src/pages/Oauth/OauthPage.jsx
+++ b/src/pages/Oauth/OauthPage.jsx
@@ -26,7 +26,7 @@ function OauthPage() {
   const accessToken = params.get('access_token');
 
   // 최초 로그인 여부를 받아와 분기 처리
-  const getisFirstLogin = async (user_id) => {
+  const getIsFirstLogin = async (user_id) => {
     try {
       // user.id로 DB에서 사용자 정보 조회
       const { data, error } = await supabase.from('user').select().eq('user_id', `${user_id}`);
@@ -34,10 +34,12 @@ function OauthPage() {
 
       if (error) {
         console.error(error);
-        isFailedModalOpen(true);
+        setIsFailedModalOpen(true);
         throw error;
       }
 
+      console.table(user);
+      console.log('최초 로그인 여부 =', user.is_first_login);
       if (user.is_first_login) {
         // 최초 로그인인 경우 최초 로그인 여부를 DB에 업데이트하고 설문 페이지로 이동
         setNextPage('/survey');
@@ -52,7 +54,7 @@ function OauthPage() {
       }
     } catch (error) {
       console.error(error);
-      isFailedModalOpen(true);
+      setIsFailedModalOpen(true);
       throw error;
     }
   };
@@ -65,12 +67,12 @@ function OauthPage() {
 
       if (error) {
         console.error(error);
-        isFailedModalOpen(true);
+        setIsFailedModalOpen(true);
         throw error;
       }
     } catch (error) {
       console.error(error);
-      isFailedModalOpen(true);
+      setIsFailedModalOpen(true);
       throw error;
     }
   };
@@ -103,7 +105,7 @@ function OauthPage() {
             });
 
             // 최초 로그인 여부에 따라 분기
-            getisFirstLogin(userData.id);
+            getIsFirstLogin(userData.id);
             return;
           } else {
             console.error('no User Data');

--- a/src/pages/Oauth/OauthPage.module.css
+++ b/src/pages/Oauth/OauthPage.module.css
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/pages/PetPage/EditPetProfilePage/EditPetProfilePage.jsx
+++ b/src/pages/PetPage/EditPetProfilePage/EditPetProfilePage.jsx
@@ -229,7 +229,6 @@ function EditPetProfilePage() {
                     })
                   }
                 />
-                {/* TODO 유효성 검사 에러 메시지 추가 */}
                 <div className={`${styles.errorMsg}`}>{errorMsg.weight}</div>
               </div>
               <div className={styles.buttonWrapper}>

--- a/src/pages/PetPage/PetProfilePage/PetProfilePage.jsx
+++ b/src/pages/PetPage/PetProfilePage/PetProfilePage.jsx
@@ -14,7 +14,6 @@ function PetProfilePage() {
   const location = useLocation();
   const { petId } = useParams();
   const { petData } = location.state || {};
-  const { deleteProfileData } = usePetProfileSurvey(); // TODO 기능 분리 후 삭제
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const [isDeleteSuccess, setIsDeleteSuccess] = useState(false);
   const [isDeleteFailed, setIsDeleteFailed] = useState(false);


### PR DESCRIPTION
## 연관된 이슈

> #76 

## 작업 내용

> **1. OAuth 페이지에 최초 로그인 시 `survey` 페이지로 이동하도록 분기를 추가했습니다.**
> - DB user 테이블에 `is_first_login` 데이터를 추가하고, 기본값을 TRUE로 설정했습니다.
> - 소셜 로그인 후 DB에서 유저 정보를 조회했을 때 `is_first_login`의 값에 따라 다른 페이지로 이동하도록 분기를 추가했습니다.
>     - `is_first_login`가 TRUE인 경우 `is_first_login`을 FALSE로 업데이트하고 `/survey`로 이동합니다.
>     - `is_first_login`가 FALSE인 경우 `/home`으로 이동합니다.
> - OAuth 페이지에 로딩 프로그레스를 추가했습니다.
>
> **2. OAuth 페이지, MyAccount 페이지의 alert를 모달로 변경했습니다.**
> - OAuth 페이지의 alert를 삭제하고, 로그인 성공/실패 모달을 추가했습니다.
> - MyAccount 페이지의 alert를 삭제하고, 로그아웃 및 회원탈퇴 확인/성공/실패 모달을 추가했습니다.
>
> **3. 기타 불필요한 코드를 제거했습니다.**

### 스크린샷 (선택)

## 리뷰 요구사항(선택)

> 