### PR TITLE
fix: Header 장바구니 버튼 주석 처리 #84 close

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -20,7 +20,7 @@ function Header() {
   return (
     <div className={styles.headerLayout}>
       <Logo />
-      <ShoppingCartIcon onClick={handleCartClick} style={{ cursor: 'pointer' }} />
+      {/* <ShoppingCartIcon onClick={handleCartClick} style={{ cursor: 'pointer' }} /> */}
     </div>
   );
 }


### PR DESCRIPTION
## 연관된 이슈

> #84 

## 작업 내용

> Header에서 장바구니 버튼이 보이지 않도록 주석 처리했습니다.

### 스크린샷 (선택)

## 리뷰 요구사항(선택)

> 
