### PR TITLE
feat : 주문페이지 주소 도로명주소 검색으로 구현 / 홈페이지에서 카테고리 클릭시 해당 카테고리의 쇼핑 페이지로 이동 /…

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,5 +11,7 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <!-- public/index.html -->
+<script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
   </body>
 </html>

--- a/src/components/HomePage/Category.jsx
+++ b/src/components/HomePage/Category.jsx
@@ -7,15 +7,20 @@ import Food from '../../assets/icons/category/foods.svg?react';
 import Clean from '../../assets/icons/category/clean.svg?react';
 import Outdoor from '../../assets/icons/category/outdoor.svg?react';
 import Toy from '../../assets/icons/category/toy.svg?react';
+
 export default function Category() {
   const navigate = useNavigate();
+
+  const handleNavigate = (category) => {
+    navigate(`/products?category=${encodeURIComponent(category)}`);
+  };
 
   return (
     <>
       <h3>카테고리</h3>
 
       <Paper
-        sx={(theme) => ({
+        sx={{
           p: 2,
           margin: 'auto',
           marginBottom: '15px',
@@ -25,10 +30,10 @@ export default function Category() {
           borderRadius: '8px',
           backgroundColor: '#fff',
           boxShadow: '0px 0px 8px 0px rgba(51, 51, 51, 0.08)',
-        })}
+        }}
       >
         <Grid container spacing={10}>
-          <Grid item>
+          <Grid item onClick={() => handleNavigate('사료/간식')}>
             <Grid item xs container direction="column" alignItems="center">
               <Food />
               <Typography variant="button" sx={{ display: 'block' }}>
@@ -37,7 +42,7 @@ export default function Category() {
             </Grid>
           </Grid>
 
-          <Grid item>
+          <Grid item onClick={() => handleNavigate('위생/배변')}>
             <Grid item xs container direction="column" alignItems="center">
               <Clean />
               <Typography variant="button" sx={{ display: 'block' }}>
@@ -46,7 +51,7 @@ export default function Category() {
             </Grid>
           </Grid>
 
-          <Grid item>
+          <Grid item onClick={() => handleNavigate('의류')}>
             <Grid item xs container direction="column" alignItems="center">
               <Outdoor />
               <Typography variant="button" sx={{ display: 'block' }}>
@@ -55,7 +60,7 @@ export default function Category() {
             </Grid>
           </Grid>
 
-          <Grid item>
+          <Grid item onClick={() => handleNavigate('장난감')}>
             <Grid item xs container direction="column" alignItems="center">
               <Toy />
               <Typography variant="button" sx={{ display: 'block' }}>

--- a/src/components/PaymentsPage/DeliveryInfo.jsx
+++ b/src/components/PaymentsPage/DeliveryInfo.jsx
@@ -2,34 +2,59 @@ import { useEffect, useState } from 'react';
 import useDeliveryStore from '../../stores/useDeliveryStore';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Plus from '../../assets/icons/plus_info.svg?react';
-import ButtonMedium from '../../components/Common/Button/ButtonMedium';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
-import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
 export default function DeliveryInfo() {
   const [save, setSave] = useState(true);
   const { name, number, address, detailAddress, setName, setNumber, setAddress, setDetailAddress } = useDeliveryStore();
 
-  // 모든 필드가 채워졌는지 확인
   const isFormComplete = name && number && address && detailAddress;
 
   const handleInfo = () => {
     setSave(false);
   };
 
+  const handleAddressSearch = () => {
+    new window.daum.Postcode({
+      oncomplete: function (data) {
+        let addr = ''; // 주소 변수
+        let extraAddr = ''; // 참고항목 변수
+
+        if (data.userSelectedType === 'R') {
+          addr = data.roadAddress;
+        } else {
+          addr = data.jibunAddress;
+        }
+
+        if (data.userSelectedType === 'R') {
+          if (data.bname !== '' && /[동|로|가]$/g.test(data.bname)) {
+            extraAddr += data.bname;
+          }
+          if (data.buildingName !== '' && data.apartment === 'Y') {
+            extraAddr += (extraAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+          }
+          if (extraAddr !== '') {
+            extraAddr = ` (${extraAddr})`;
+          }
+        }
+
+        setAddress(`${addr} ${extraAddr}`);
+      },
+    }).open();
+  };
+
   return (
     <>
       <h3>배송지 정보</h3>
       <Paper
-        sx={(theme) => ({
+        sx={{
           p: 2,
           margin: 'auto',
           marginBottom: '15px',
@@ -38,7 +63,7 @@ export default function DeliveryInfo() {
           flexGrow: 1,
           backgroundColor: '#fff',
           boxShadow: '0px 0px 8px 0px rgba(51, 51, 51, 0.08)',
-        })}
+        }}
       >
         {save ? (
           <Accordion sx={{ borderRadius: '8px', backgroundColor: 'var(--primary-bright)' }}>
@@ -47,16 +72,43 @@ export default function DeliveryInfo() {
               <Typography>배송지 정보 추가하기</Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <TextField sx={{ mb: 1 }} fullWidth required id="outlined-required" label="이름을 입력해주세요" onChange={(e) => setName(e.target.value)} />
-              <TextField sx={{ mb: 1 }} fullWidth required id="outlined-required" label="전화번호를 입력해주세요" onChange={(e) => setNumber(e.target.value)} />
               <TextField
                 sx={{ mb: 1 }}
                 fullWidth
                 required
                 id="outlined-required"
-                label="도로명 주소를 입력해주세요"
-                onChange={(e) => setAddress(e.target.value)}
+                label="이름을 입력해주세요"
+                onChange={(e) => setName(e.target.value)}
               />
+              <TextField
+                sx={{ mb: 1 }}
+                fullWidth
+                required
+                id="outlined-required"
+                label="전화번호를 입력해주세요"
+                onChange={(e) => setNumber(e.target.value)}
+              />
+
+              <Grid container spacing={1} sx={{ mb: 1 }}>
+                <Grid item xs={9}>
+                  <TextField
+                    fullWidth
+                    required
+                    id="outlined-required"
+                    label="도로명 주소를 입력해주세요"
+                    value={address}
+                    onChange={(e) => setAddress(e.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={3}>
+                  <Button variant="outlined" onClick={handleAddressSearch} sx={{ height: '100%' }}>
+                    주소 
+                    <br></br>
+                    검색
+                  </Button>
+                </Grid>
+              </Grid>
+
               <TextField
                 sx={{ mb: 1 }}
                 fullWidth
@@ -67,8 +119,14 @@ export default function DeliveryInfo() {
               />
 
               <Grid sx={{ mt: 2 }}>
-              <Button onClick={handleInfo} disabled={!isFormComplete} variant="contained" size="large" sx={{ width: '100%', borderRadius: '8px', backgroundColor: 'var(--primary-default)' }}>
-                확인
+                <Button
+                  onClick={handleInfo}
+                  disabled={!isFormComplete}
+                  variant="contained"
+                  size="large"
+                  sx={{ width: '100%', borderRadius: '8px', backgroundColor: 'var(--primary-default)' }}
+                >
+                  확인
                 </Button>
               </Grid>
             </AccordionDetails>

--- a/src/components/PaymentsPage/DeliveryInfo.jsx
+++ b/src/components/PaymentsPage/DeliveryInfo.jsx
@@ -38,7 +38,7 @@ export default function DeliveryInfo() {
             extraAddr += data.bname;
           }
           if (data.buildingName !== '' && data.apartment === 'Y') {
-            extraAddr += (extraAddr !== '' ? ', ' + data.buildingName : data.buildingName);
+            extraAddr += extraAddr !== '' ? ', ' + data.buildingName : data.buildingName;
           }
           if (extraAddr !== '') {
             extraAddr = ` (${extraAddr})`;
@@ -72,39 +72,29 @@ export default function DeliveryInfo() {
               <Typography>배송지 정보 추가하기</Typography>
             </AccordionSummary>
             <AccordionDetails>
-              <TextField
-                sx={{ mb: 1 }}
-                fullWidth
-                required
-                id="outlined-required"
-                label="이름을 입력해주세요"
-                onChange={(e) => setName(e.target.value)}
-              />
-              <TextField
-                sx={{ mb: 1 }}
-                fullWidth
-                required
-                id="outlined-required"
-                label="전화번호를 입력해주세요"
-                onChange={(e) => setNumber(e.target.value)}
-              />
+              <TextField sx={{ mb: 1 }} fullWidth required id="outlined-required" label="이름을 입력해주세요" onChange={(e) => setName(e.target.value)} />
+              <TextField sx={{ mb: 1 }} fullWidth required id="outlined-required" label="전화번호를 입력해주세요" onChange={(e) => setNumber(e.target.value)} />
 
               <Grid container spacing={1} sx={{ mb: 1 }}>
                 <Grid item xs={9}>
                   <TextField
                     fullWidth
                     required
-                    id="outlined-required"
+                    id="outlined-read-only-input"
                     label="도로명 주소를 입력해주세요"
+                    defaultValue="도로명 주소"
                     value={address}
                     onChange={(e) => setAddress(e.target.value)}
+                    slotProps={{
+                      input: {
+                        readOnly: true,
+                      },
+                    }}
                   />
                 </Grid>
                 <Grid item xs={3}>
                   <Button variant="outlined" onClick={handleAddressSearch} sx={{ height: '100%' }}>
-                    주소 
-                    <br></br>
-                    검색
+                    주소 검색
                   </Button>
                 </Grid>
               </Grid>

--- a/src/pages/ShopPage/ProductListPage.jsx
+++ b/src/pages/ShopPage/ProductListPage.jsx
@@ -1,6 +1,6 @@
-// 쇼핑 페이지
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useLocation, useNavigate } from 'react-router-dom';
 import ShopTabBar from '../../components/ProductList/ShopTabBar';
 import ProductItem from '../../components/ProductList/ProductItem';
 import styles from './ProductListPage.module.css';
@@ -13,45 +13,59 @@ const Wrapper = styled.section`
 `;
 
 const ProductListPage = () => {
-  const [activeTab, setActiveTab] = useState('전체'); // 상위 컴포넌트에서 activeTab 상태 관리
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState('전체'); // 기본 탭은 '전체'로 설정
   const { products, fetchProducts } = useProductStore();
   
   const fetchData = async () => {
-  await fetchProducts(); // 비동기 함수 호출
+    await fetchProducts(); // 비동기 함수 호출
   };
 
   useEffect(() => {
     fetchData();
   }, []);
-  
+
+  // 쿼리 매개변수로 전달된 카테고리를 읽어와 activeTab을 설정
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const category = params.get('category');
+    if (category) {
+      setActiveTab(category); // 쿼리 매개변수를 통해 activeTab 설정
+    }
+  }, [location.search]);
+
+  // 탭을 전환할 때 URL의 쿼리 매개변수를 업데이트
+  const handleTabChange = (tab) => {
+    setActiveTab(tab);
+    navigate(`/products?category=${tab}`); // URL 쿼리 매개변수 업데이트
+  };
+
+  // 선택된 탭에 따라 제품을 필터링
   const filteredProducts = products.filter((product) => {
     if (activeTab === '전체') return true; // 모든 제품 반환
-    if (activeTab === '사료/간식') {
-      return product.category_id==1;
-    }
-    if (activeTab === '위생/배변') {
-      return product.category_id==2;
-    }
-    if (activeTab === '의류') {
-      return product.category_id==3;
-    }
-    if (activeTab === '장난감') {
-      return product.category_id==4;
-    } 
-    if (activeTab=== "추천상품") {
-      return ![1, 2, 3, 4].includes(product.category_id); // 1,2,3,4에 포함되지 않는 제품 반환
-    }
-    return false; // 다섯 개의 조건에 해당되지 않는 경우
+    if (activeTab === '사료/간식') return product.category_id === 1;
+    if (activeTab === '위생/배변') return product.category_id === 2;
+    if (activeTab === '의류') return product.category_id === 3;
+    if (activeTab === '장난감') return product.category_id === 4;
+    if (activeTab === '추천상품') return ![1, 2, 3, 4].includes(product.category_id); // 1,2,3,4에 포함되지 않는 제품 반환
+    return false;
   });
 
   return (
     <>
       <Header />
       <Wrapper>
-        <ShopTabBar activeTab={activeTab} onTabChange={setActiveTab} /> {/* activeTab을 ShopTabBar로 전달 */}
+        <ShopTabBar activeTab={activeTab} onTabChange={handleTabChange} /> {/* activeTab을 ShopTabBar로 전달 */}
         <div className={styles.itemWrapper}>
           {filteredProducts.map((product) => (
-            <ProductItem key={product.product_id} id={product.product_id} title={product.product_name} price={product.price} imageSrc={product.image_url_1} />
+            <ProductItem
+              key={product.product_id}
+              id={product.product_id}
+              title={product.product_name}
+              price={product.price}
+              imageSrc={product.image_url_1}
+            />
           ))}
         </div>
       </Wrapper>


### PR DESCRIPTION
… 쇼핑 페이지도 수정

## 연관된 이슈

> ex) #83 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
![화면 캡처 2024-11-01 140740](https://github.com/user-attachments/assets/f5635a72-bba4-4be2-89c5-402004c5d5c2)

도로명 주소 검색 api 진행

홈 화면에서 카테고리 선택하면 해당 탭 선택된 채로 쇼핑 탭으로 가도록 변경



### 스크린샷 (선택)

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
