### PR TITLE
86 feat order cancel

### DIFF
--- a/src/components/Mypage/MyOrder.jsx
+++ b/src/components/Mypage/MyOrder.jsx
@@ -33,17 +33,14 @@ export default function MyOrder() {
 
   const getSuccessData = async () => {
     // payment 테이블에서 payment_state가 success인 데이터만 order 테이블의 정보를 가져옴
-    const { data, error } = await supabase
-    .from('payment')
-    .select('order_id, order(*)')
-    .eq('payment_state', 'success');
-      
+    const { data, error } = await supabase.from('payment').select('order_id, order(*)').eq('payment_state', 'success');
+
     if (error) {
       console.error('Error fetching data:', error);
       return;
     }
 
-    const filteredData = data?.filter(item => item.order.user_id === user.id);
+    const filteredData = data?.filter((item) => item.order.user_id === user.id);
 
     if (filteredData) {
       setSuccessProduct(filteredData);
@@ -65,7 +62,7 @@ export default function MyOrder() {
         <>
           <Info>
             <h3>최근 구매 내역</h3>
-            <Detail onClick={() => navigate('/mypage/order')}>주문 상세 &gt;</Detail>
+            <Detail onClick={() => navigate('/mypage/order')}>주문 내역 보기 &gt;</Detail>
           </Info>
           <Paper
             sx={(theme) => ({
@@ -80,23 +77,39 @@ export default function MyOrder() {
               boxShadow: '0px 0px 8px 0px rgba(51, 51, 51, 0.08)',
             })}
           >
-            <Grid item container spacing={2} sx={{ color: 'text.secondary', marginLeft: '4px', marginBottom: '6px' }}>
-              <Typography variant="body2" component="div">
-                {new Date(successProduct[successProduct.length - 1].order.created_at)
-                  .toLocaleString('ko-KR', {
-                    year: 'numeric',
-                    month: '2-digit',
-                    day: '2-digit',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hour12: false,
-                  })
-                  .replace(/\.$/, '')}
-                &nbsp; &nbsp;
-              </Typography>
-              <Typography variant="body2" component="div">
-                결제 완료
-              </Typography>
+            <Grid
+              item
+              container
+              sx={{ color: 'text.secondary', marginLeft: '4px', marginBottom: '6px', justifyContent: 'space-between', alignItems: 'center' }}
+            >
+              <Grid item>
+                <Typography variant="body2" component="div">
+                  {new Date(successProduct[successProduct.length - 1].order.created_at)
+                    .toLocaleString('ko-KR', {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      hour12: false,
+                    })
+                    .replace(/\.$/, '')}
+                  &nbsp; 결제 완료
+                </Typography>
+              </Grid>
+
+              <Grid item>
+                {successProduct[successProduct.length - 1].order.order_status === 'cancel' ? (
+                  <Typography sx={{ color: '#EA4646' }}>주문 취소</Typography>
+                ) : (
+                  <Typography
+                    onClick={() => navigate(`/mypage/order/detail?order_id=${successProduct[successProduct.length - 1].order_id}`)}
+                    sx={{ cursor: 'pointer' }}
+                  >
+                    주문 상세 &gt;
+                  </Typography>
+                )}
+              </Grid>
             </Grid>
 
             <Grid container spacing={2}>

--- a/src/components/Mypage/OrderPage/OrderList.jsx
+++ b/src/components/Mypage/OrderPage/OrderList.jsx
@@ -41,7 +41,13 @@ export default function OrderList({ item }) {
           </Grid>
 
           <Grid item>
-            <Typography onClick={() => navigate(`/mypage/order/detail?order_id=${item.order_id}`)} sx={{ cursor: "pointer"}}>주문 상세 &gt;</Typography>
+            {item.order.order_status === 'cancel' ? (
+              <Typography sx={{ color: "#EA4646" }}>주문 취소</Typography>
+            ) : (
+              <Typography onClick={() => navigate(`/mypage/order/detail?order_id=${item.order_id}`)} sx={{ cursor: "pointer" }}>
+                주문 상세 &gt;
+              </Typography>
+            )}
           </Grid>
         </Grid>
 

--- a/src/components/PaymentsPage/OrderInfo.jsx
+++ b/src/components/PaymentsPage/OrderInfo.jsx
@@ -9,7 +9,6 @@ import { Button } from '@mui/material';
 import useTotalStore from '../../stores/useTotalStore';
 import NumberPicker from '../ProductDetail/NumberPicker';
 import { useProductStore } from '../../stores/useProductStore';
-import ButtonLarge from '../../components/Common/Button/ButtonLarge';
 import useDeliveryStore from '../../stores/useDeliveryStore';
 import supabase from '../../services/supabaseClient';
 import { useAuthStore } from '../../stores/useAuthStore';

--- a/src/components/PaymentsPage/OrderInfo.jsx
+++ b/src/components/PaymentsPage/OrderInfo.jsx
@@ -45,8 +45,6 @@ export default function OrderInfo() {
   };
 
   const handlePayment = async () => {
-    console.log(product.image_url_1);
-    console.log(product.product_name);
     // order table에 주문 데이터 삽입
     const dataToPost = {
       user_id: user.id,

--- a/src/pages/MyPage/OrderDetailPage/OrderDetailPage.jsx
+++ b/src/pages/MyPage/OrderDetailPage/OrderDetailPage.jsx
@@ -8,7 +8,7 @@ import DetailBar from '../../../stories/DetailBar';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import supabase from '../../../services/supabaseClient';
 import { Button } from '@mui/material';
-import DefaultModal from '../../../components/Common/Modal/DefaultModal';
+import YesNoModal from '../../../components/Common/Modal/DefaultModal';
 
 const Wrapper = styled.section`
   margin-left: 24px;
@@ -19,6 +19,7 @@ function OrderDetailPage() {
   const [searchParams] = useSearchParams();
   const order_id = searchParams.get('order_id');
   const [product, setProduct] = useState(null);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 
   const getProductData = async () => {
     // payment 테이블에서 payment_state가 success이고 order_id가 일치하는 데이터만 가져옴
@@ -36,7 +37,11 @@ function OrderDetailPage() {
   const navigate = useNavigate();
 
   async function handleCancel() {
+    setIsConfirmModalOpen(true);
+    cancelOrder();
+  }
 
+  async function cancelOrder() {
     try {
       const { error } = await supabase
         .from('order')
@@ -48,8 +53,6 @@ function OrderDetailPage() {
         return;
       }
 
-      // 주문 삭제 후 페이지 이동
-      navigate('/mypage/order/detail');
     } catch (error) {
       console.error('Unexpected error:', error);
     }
@@ -96,6 +99,15 @@ function OrderDetailPage() {
         >
           주문 취소하기
         </Button>
+        <YesNoModal
+          title={`주문 취소 확인`}
+          content={`정말 주문 취소 하시겠어요?`}
+          isOpen={isConfirmModalOpen}
+          setIsOpen={() => setIsConfirmModalOpen(!isConfirmModalOpen)}
+          onYesClick={() => {
+            window.location.href = '/mypage/order';
+          }}
+        />
       </Wrapper>
       <Navbar selectedMenu="MyPage" />
     </>

--- a/src/pages/ShopPage/ProductListPage.jsx
+++ b/src/pages/ShopPage/ProductListPage.jsx
@@ -7,6 +7,7 @@ import styles from './ProductListPage.module.css';
 import Header from '../../components/Header/Header';
 import Navbar from '../../components/Navbar/Navbar';
 import { useProductStore } from '../../stores/useProductStore';
+import { LinearProgress } from '@mui/material';
 
 const Wrapper = styled.section`
   padding: 24px;
@@ -51,6 +52,10 @@ const ProductListPage = () => {
     if (activeTab === '추천상품') return ![1, 2, 3, 4].includes(product.category_id); // 1,2,3,4에 포함되지 않는 제품 반환
     return false;
   });
+
+  if (!products) {
+    return <p>Loading product details...</p>;
+  }
 
   return (
     <>


### PR DESCRIPTION
## 연관된 이슈

#86 

## 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 주문 내역 페이지 주문 취소 버튼 추가
- 주문이 취소돼도 내역이 남아있게  (주문 취소 상태 확인 가능하게)
    - order 테이블에 order_status 추가
        → success(주문 완료), cancel(주문 취소)

### 스크린샷 (선택)
<img width="399" alt="image" src="https://github.com/user-attachments/assets/a24d1f39-3b06-4433-810f-26d857884dfe">

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
