### PR TITLE
feat :  페스티벌 페이지 모달 추가와 배송지 입력 전화번호 폼 유효성 검사 진행, 페스티벌 페이지 로그인 유효성 검사 로직 변경

### DIFF
--- a/src/components/PaymentsPage/DeliveryInfo.jsx
+++ b/src/components/PaymentsPage/DeliveryInfo.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import useDeliveryStore from '../../stores/useDeliveryStore';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
@@ -14,11 +14,31 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 export default function DeliveryInfo() {
   const [save, setSave] = useState(true);
   const { name, number, address, detailAddress, setName, setNumber, setAddress, setDetailAddress } = useDeliveryStore();
+  const [errors, setErrors] = useState({
+    name: '',
+    number: '',
+    detailAddress: '',
+  });
 
   const isFormComplete = name && number && address && detailAddress;
 
+  // 전화번호 형식 검증을 포함한 유효성 검사 함수
+  const validateForm = () => {
+    const newErrors = {
+      name: name ? '' : '이름을 입력해주세요.',
+      detailAddress: detailAddress ? '' : '세부주소를 입력해주세요.',
+      number: /^010\d{7,8}$/.test(number) ? '' : '전화번호는 010으로 시작하고 10~11자리 숫자로 입력해주세요.',
+    };
+
+    setErrors(newErrors);
+
+    return Object.values(newErrors).every((msg) => msg === '');
+  };
+
   const handleInfo = () => {
-    setSave(false); // 폼을 닫고 배송지 정보만 표시
+    if (validateForm()) {
+      setSave(false); // 폼을 닫고 배송지 정보만 표시
+    }
   };
 
   const handleEditInfo = () => {
@@ -26,7 +46,7 @@ export default function DeliveryInfo() {
   };
 
   const handleAccordionToggle = () => {
-    setSave((prevSave) => !prevSave); // save 상태를 토글하여 아코디언을 닫거나 엽니다.
+    setSave((prevSave) => !prevSave);
   };
 
   const handleAddressSearch = () => {
@@ -58,6 +78,19 @@ export default function DeliveryInfo() {
     }).open();
   };
 
+  // 전화번호 입력 핸들러
+  const handleNumberChange = (e) => {
+    const input = e.target.value.replace(/\D/g, ''); // 숫자 이외의 문자 제거
+    setNumber(input.slice(0, 11)); // 최대 11자리로 제한
+  };
+
+  // 초기 로딩 시 번호가 없을 때 기본값을 '010'으로 설정
+  useEffect(() => {
+    if (!number) {
+      setNumber('010');
+    }
+  }, [number, setNumber]);
+
   return (
     <>
       <h3>배송지 정보</h3>
@@ -76,7 +109,7 @@ export default function DeliveryInfo() {
         {save ? (
           <Accordion
             expanded={save}
-            onChange={handleAccordionToggle} // 아코디언이 클릭될 때마다 상태를 토글합니다.
+            onChange={handleAccordionToggle}
             sx={{ borderRadius: '8px', backgroundColor: 'var(--primary-bright)' }}
           >
             <AccordionSummary expandIcon={<ArrowDropDownIcon />} aria-controls="panel2-content" id="panel2-header">
@@ -92,6 +125,8 @@ export default function DeliveryInfo() {
                 label="이름을 입력해주세요"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
+                error={Boolean(errors.name)}
+                helperText={errors.name}
               />
               <TextField
                 sx={{ mb: 1 }}
@@ -100,9 +135,11 @@ export default function DeliveryInfo() {
                 id="outlined-required"
                 label="전화번호를 입력해주세요"
                 value={number}
-                onChange={(e) => setNumber(e.target.value)}
+                onChange={handleNumberChange} // 숫자만 입력 가능
+                error={Boolean(errors.number)}
+                helperText={errors.number}
+                placeholder="010으로 시작하는 10~11자리 번호 입력"
               />
-
               <Grid container spacing={1} sx={{ mb: 1 }}>
                 <Grid item xs={9}>
                   <TextField
@@ -123,7 +160,6 @@ export default function DeliveryInfo() {
                   </Button>
                 </Grid>
               </Grid>
-
               <TextField
                 sx={{ mb: 1 }}
                 fullWidth
@@ -132,8 +168,9 @@ export default function DeliveryInfo() {
                 label="세부주소를 입력해주세요"
                 value={detailAddress}
                 onChange={(e) => setDetailAddress(e.target.value)}
+                error={Boolean(errors.detailAddress)}
+                helperText={errors.detailAddress}
               />
-
               <Grid sx={{ mt: 2 }}>
                 <Button
                   onClick={handleInfo}
@@ -152,7 +189,6 @@ export default function DeliveryInfo() {
             <Typography gutterBottom variant="subtitle3" component="div" sx={{ fontWeight: 'bold', marginLeft: '10px', marginBottom: '20px' }}>
               {name}
             </Typography>
-
             <Grid item container spacing={2} sx={{ color: 'text.secondary', marginLeft: '10px', flexDirection: 'column' }}>
               <Typography variant="body2" component="div">
                 {number}
@@ -161,7 +197,6 @@ export default function DeliveryInfo() {
                 {address} {detailAddress}
               </Typography>
             </Grid>
-
             <Button variant="outlined" onClick={handleEditInfo} sx={{ mt: 2, width: '100%', borderRadius: '8px' }}>
               배송지 변경하기
             </Button>


### PR DESCRIPTION
## 연관된 이슈

> ex) #117 

## 작업 내용

1. festival 페이지 (리스트, 디테일) 에서 신청 취소 / 참여 신청 누를 시 모달으로 확인하게 변경

![화면 캡처 2024-11-05 160637](https://github.com/user-attachments/assets/4b0a730f-2823-47c1-b3ce-8e976ce8db25)
![화면 캡처 2024-11-05 160703](https://github.com/user-attachments/assets/dbc1b29e-745c-48ef-a2b1-82327770f7b2)

2. 배송지 입력시 전화번호 유효성 검사 진행하여, 양식을 지키지 않을 시 경고 문구 출력
![화면 캡처 2024-11-05 160616](https://github.com/user-attachments/assets/4534f81c-da81-4e46-b200-a2c35c88cf73)

3. 페스티벌 페이지 진입시가 아닌, 신청 취소 / 참여 신청을 누를 시 로그인 유효성 검사를 실행하도록 변경
### 스크린샷 (선택)



## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
